### PR TITLE
Updating the license field format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ authors = [{name = "OMEGA_RAZER"}]
 description = "Prowlpy is a python library that implements the public api of Prowl to send push notification to iPhones."
 keywords = ["prowl", "push", "notification", "iphone"]
 readme = "README.md"
-license = {file = "LICENSE"}
+license = "GPL-3.0-only"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Updating the license field to a format that HomeAssistants CI/CD can handle it.

Looking at [PIP licensing guide](https://packaging.python.org/en/latest/guides/licensing-examples-and-user-scenarios/) it looks like the format needs tweaking.

The `LICENSE` file appears to be [GPL 3.0](https://spdx.org/licenses/GPL-3.0-only.html), so have updated with that in mind.